### PR TITLE
Fix tstats Time Bucketing

### DIFF
--- a/IllumioAppforSplunk/default/data/ui/views/change_monitoring.xml
+++ b/IllumioAppforSplunk/default/data/ui/views/change_monitoring.xml
@@ -3,7 +3,7 @@
   <description>View recent changes made on connected Illumio PCEs</description>
   <search id="audit_base_search">
     <query>
-      | tstats `summariesonly` count FROM datamodel=Illumio.Audit WHERE Audit.category="auditable" (Audit.action="created" OR Audit.action="updated" OR Audit.action="deleted") Audit.pce_fqdn=$pce_tok|s$ Audit.org_id=$org_id_tok|s$ (Audit.user=$user_tok|s$ OR Audit.src_user=$user_tok|s$) Audit.object_category=$resource_type_tok|s$ BY _time Audit.action Audit.object_category Audit.user
+      | tstats `summariesonly` count FROM datamodel=Illumio.Audit WHERE Audit.category="auditable" (Audit.action="created" OR Audit.action="updated" OR Audit.action="deleted") Audit.pce_fqdn=$pce_tok|s$ Audit.org_id=$org_id_tok|s$ (Audit.user=$user_tok|s$ OR Audit.src_user=$user_tok|s$) Audit.object_category=$resource_type_tok|s$ BY _time Audit.timestamp Audit.action Audit.object_category Audit.user
     </query>
     <earliest>$time_range.earliest$</earliest>
     <latest>$time_range.latest$</latest>

--- a/IllumioAppforSplunk/default/data/ui/views/firewall_tampering_host.xml
+++ b/IllumioAppforSplunk/default/data/ui/views/firewall_tampering_host.xml
@@ -7,7 +7,6 @@
         <search>
           <query>
             | savedsearch Illumio_Firewall_Tampering
-            | eval Timestamp = strftime(_time, "%Y-%m-%d %H:%M:%S %Z")
             | lookup illumio_workloads_lookup ven.href AS ven_href OUTPUTNEW href AS workload_href, labels AS Labels
                 ```Map workload label HREFs to key:value pairs for display```
             | lookup illumio_labels_lookup href AS Labels, pce_fqdn, org_id OUTPUT key AS label_key, value AS label_value
@@ -22,6 +21,9 @@
             | eval Quarantine = if(show_quarantine=1, "Quarantine Workload", "")
             | table Timestamp, pce_fqdn, org_id, Labels, workload_hostname, Quarantine, workload_href
             | rename pce_fqdn AS PCE, org_id AS "Org ID", workload_hostname AS Hostname
+            | eval Timestamp = strptime(Timestamp, "%Y-%m-%dT%H:%M:%S%Z")
+            | fieldformat Timestamp = strftime(Timestamp, "%+")
+            | sort -Timestamp
           </query>
           <earliest>$earliest$</earliest>
           <latest>$latest$</latest>

--- a/IllumioAppforSplunk/default/data/ui/views/pce_user_authentication.xml
+++ b/IllumioAppforSplunk/default/data/ui/views/pce_user_authentication.xml
@@ -2,7 +2,7 @@
   <label>PCE Authentication Events</label>
   <search id="audit_base_search">
     <query>
-      | tstats `summariesonly` values(Audit.timestamp) AS Timestamp, values(Audit.src_user) AS src_user, values(Audit.user) AS user, values(Audit.src_ip) AS src_ip FROM datamodel=Illumio.Audit WHERE Audit.pce_fqdn=$pce_tok|s$ Audit.org_id=$org_id_tok|s$ (Audit.user=$user_tok|s$ OR Audit.src_user=$user_tok|s$) (Audit.category="auditable" OR Audit.category="system_events") Audit.event_type="user.*" BY _time Audit.pce_fqdn Audit.href Audit.event_type Audit.status Audit.severity Audit.notification_type
+      | tstats `summariesonly` values(Audit.timestamp) AS Timestamp, values(Audit.src_user) AS src_user, values(Audit.user) AS user, values(Audit.src_ip) AS src_ip FROM datamodel=Illumio.Audit WHERE Audit.pce_fqdn=$pce_tok|s$ Audit.org_id=$org_id_tok|s$ (Audit.user=$user_tok|s$ OR Audit.src_user=$user_tok|s$) (Audit.category="auditable" OR Audit.category="system_events") Audit.event_type="user.*" BY _time Audit.timestamp Audit.pce_fqdn Audit.href Audit.event_type Audit.status Audit.severity Audit.notification_type
       | rename Audit.pce_fqdn AS PCE, Audit.event_type AS event_type, Audit.notification_type AS notification_type, Audit.severity AS severity, Audit.status AS status, Audit.href AS event_href
     </query>
     <earliest>$time_range.earliest$</earliest>

--- a/IllumioAppforSplunk/default/data/ui/views/port_scan.xml
+++ b/IllumioAppforSplunk/default/data/ui/views/port_scan.xml
@@ -6,8 +6,6 @@
         <search>
           <query>
             | savedsearch Illumio_PortScan pce_fqdn=$pce_fqdn$ org_id=$org_id$
-                ```Convert timestamp here because _time gets lost in the mvcombine call later```
-            | eval Timestamp = strftime(_time, "%Y-%m-%d %H:%M:%S %Z")
                 ```Look up labels and map them to key:value pairs using illumio_labels_lookup```
             | foreach *_href [lookup illumio_workloads_lookup href AS &lt;&lt;FIELD&gt;&gt; OUTPUTNEW labels AS &lt;&lt;MATCHSTR&gt;&gt;_labels
                 | lookup illumio_labels_lookup href AS &lt;&lt;MATCHSTR&gt;&gt;_labels, pce_fqdn, org_id OUTPUT key AS label_key, value AS label_value
@@ -26,6 +24,9 @@
             | eval Quarantine = if(show_quarantine=1, "Quarantine Workload", "")
             | table Timestamp, pce_fqdn, org_id, src_ip, src_host, src_labels, dest_ip, dest_host, dest_labels, Quarantine, workload_href
             | rename pce_fqdn AS PCE, org_id AS "Org ID", src_host AS Source, src_ip AS "Source IP", src_labels AS "Source Labels", dest_host AS Destination, dest_ip AS "Destination IP", dest_labels AS "Destination Labels"
+            | eval Timestamp = strptime(Timestamp, "%Y-%m-%dT%H:%M:%S%Z")
+            | fieldformat Timestamp = strftime(Timestamp, "%+")
+            | sort -Timestamp
           </query>
           <earliest>$earliest$</earliest>
           <latest>$latest$</latest>

--- a/IllumioAppforSplunk/default/data/ui/views/security_operations.xml
+++ b/IllumioAppforSplunk/default/data/ui/views/security_operations.xml
@@ -2,7 +2,7 @@
   <label>Security Operations</label>
   <search id="traffic_base_search">
     <query>
-      | tstats `summariesonly` sum(Traffic.count) AS flows, values(Traffic.src_host) AS src_host, values(Traffic.dest_host) AS dest_host FROM datamodel=Illumio.Traffic WHERE Traffic.pce_fqdn=$pce_tok|s$ Traffic.action=$action_tok|s$ Traffic.org_id=$org_id_tok|s$ BY _time Traffic.src_ip Traffic.dest_ip Traffic.dest_port Traffic.transport Traffic.action
+      | tstats `summariesonly` sum(Traffic.count) AS flows, values(Traffic.src_host) AS src_host, values(Traffic.dest_host) AS dest_host FROM datamodel=Illumio.Traffic WHERE Traffic.pce_fqdn=$pce_tok|s$ Traffic.action=$action_tok|s$ Traffic.org_id=$org_id_tok|s$ BY _time Traffic.timestamp Traffic.src_ip Traffic.dest_ip Traffic.dest_port Traffic.transport Traffic.action
       | rename Traffic.src_ip AS src_ip, Traffic.dest_ip AS dest_ip, Traffic.dest_port AS dest_port, Traffic.transport AS transport, Traffic.action AS action
     </query>
     <earliest>$time_range.earliest$</earliest>

--- a/IllumioAppforSplunk/default/data/ui/views/traffic_explorer.xml
+++ b/IllumioAppforSplunk/default/data/ui/views/traffic_explorer.xml
@@ -2,7 +2,7 @@
   <label>Traffic Explorer</label>
   <search id="traffic_base_search">
     <query>
-        | tstats `summariesonly` sum(Traffic.count) AS flows, values(Traffic.src_host) AS src_host, values(Traffic.dest_host) AS dest_host, values(Traffic.direction) AS direction, values(Traffic.transport) AS transport, values(Traffic.src_label_pairs) AS src_labels, values(Traffic.dest_label_pairs) AS dest_labels FROM datamodel=Illumio.Traffic WHERE Traffic.pce_fqdn=$pce_tok|s$ Traffic.org_id=$org_id_tok|s$ (Traffic.src_ip=$src_host_ip|s$ OR Traffic.src_host=$src_host_ip|s$) (Traffic.dest_ip=$dest_host_ip|s$ OR Traffic.dest_host=$dest_host_ip|s$) ($src_label_filter$ OR $dest_label_filter$) Traffic.transport=$protocol_tok|s$ Traffic.dest_port IN $port_filter$ Traffic.action IN $action_filter$ BY _time Traffic.pce_fqdn Traffic.src_ip Traffic.dest_ip Traffic.dest_port Traffic.action
+        | tstats `summariesonly` sum(Traffic.count) AS flows, values(Traffic.src_host) AS src_host, values(Traffic.dest_host) AS dest_host, values(Traffic.direction) AS direction, values(Traffic.transport) AS transport, values(Traffic.src_label_pairs) AS src_labels, values(Traffic.dest_label_pairs) AS dest_labels FROM datamodel=Illumio.Traffic WHERE Traffic.pce_fqdn=$pce_tok|s$ Traffic.org_id=$org_id_tok|s$ (Traffic.src_ip=$src_host_ip|s$ OR Traffic.src_host=$src_host_ip|s$) (Traffic.dest_ip=$dest_host_ip|s$ OR Traffic.dest_host=$dest_host_ip|s$) ($src_label_filter$ OR $dest_label_filter$) Traffic.transport=$protocol_tok|s$ Traffic.dest_port IN $port_filter$ Traffic.action IN $action_filter$ BY _time Traffic.timestamp Traffic.pce_fqdn Traffic.src_ip Traffic.dest_ip Traffic.dest_port Traffic.action
     </query>
     <earliest>$time_range.earliest$</earliest>
     <latest>$time_range.latest$</latest>
@@ -175,11 +175,13 @@
       <table id="resubmit_on_click_1">
         <search base="traffic_base_search">
           <query>
-            | stats sum(flows) AS Flows BY Traffic.dest_port
-            | rename Traffic.dest_port AS Port
+            | rename Traffic.dest_port AS port
+            | eval Port = if(port &gt; 0, port . " ", "") . upper(transport)
+            | stats sum(flows) AS Flows, values(port) AS port, values(transport) AS transport BY Port
             | sort -Flows
           </query>
         </search>
+        <fields>Port Flows</fields>
         <option name="count">5</option>
         <option name="drilldown">row</option>
         <option name="refresh.display">progressbar</option>
@@ -190,7 +192,8 @@
           <scale type="minMidMax"></scale>
         </format>
         <drilldown>
-          <set token="form.port_filter">$click.value$</set>
+          <set token="form.port_filter">$row.port$</set>
+          <set token="form.protocol_tok">$row.transport$</set>
         </drilldown>
       </table>
     </panel>
@@ -254,9 +257,10 @@
           <query>
             | eval Source = if(isnotnull(src_host), src_host, 'Traffic.src_ip')
             | eval Destination = if(isnotnull(dest_host), dest_host, 'Traffic.dest_ip')
-            | table _time, Traffic.pce_fqdn, Source, direction, Destination, Traffic.dest_port, transport, flows, Traffic.action, src_labels, dest_labels
-            | rename _time AS Timestamp, Traffic.pce_fqdn AS "PCE", direction AS Direction, Traffic.dest_port AS "Port", transport AS Protocol, flows AS Flows, Traffic.action AS "Policy Decision", src_labels AS "Source Labels", dest_labels AS "Destination Labels"
+            | table Traffic.timestamp, Traffic.pce_fqdn, Source, direction, Destination, Traffic.dest_port, transport, flows, Traffic.action, src_labels, dest_labels
+            | rename Traffic.timestamp AS Timestamp, Traffic.pce_fqdn AS "PCE", direction AS Direction, Traffic.dest_port AS "Port", transport AS Protocol, flows AS Flows, Traffic.action AS "Policy Decision", src_labels AS "Source Labels", dest_labels AS "Destination Labels"
             | fillnull value="-" "Source Labels" "Destination Labels"
+            | eval Timestamp = strptime(Timestamp, "%Y-%m-%dT%H:%M:%S%Z")
             | fieldformat Timestamp = strftime(Timestamp, "%+")
             | sort -Timestamp
           </query>

--- a/IllumioAppforSplunk/default/data/ui/views/workload_investigation.xml
+++ b/IllumioAppforSplunk/default/data/ui/views/workload_investigation.xml
@@ -10,7 +10,7 @@
   </search>
   <search id="audit_base_search">
     <query>
-      | tstats `summariesonly` values(Audit.src_user) AS src_user, values(Audit.user) AS user, values(Audit.src_ip) AS src_ip, values(Audit.notification_type) AS notification_type, values(Audit.severity) AS severity, values(Audit.status) AS status, values(Audit.pce_fqdn) AS pce_fqdn, values(Audit.event_type) AS event_type, values(Audit.object_id) AS object_id FROM datamodel=Illumio.Audit WHERE Audit.pce_fqdn=$pce_tok|s$ Audit.org_id=$org_id_tok|s$ (Audit.event_type="agent.*" OR Audit.event_type="workload.*" OR Audit.event_type="workloads.*") Audit.event_type!="*.create" Audit.event_type!="*.update" Audit.event_type!="*.delete" BY _time Audit.href
+      | tstats `summariesonly` values(Audit.src_user) AS src_user, values(Audit.user) AS user, values(Audit.src_ip) AS src_ip, values(Audit.notification_type) AS notification_type, values(Audit.severity) AS severity, values(Audit.status) AS status, values(Audit.pce_fqdn) AS pce_fqdn, values(Audit.event_type) AS event_type, values(Audit.object_id) AS object_id FROM datamodel=Illumio.Audit WHERE Audit.pce_fqdn=$pce_tok|s$ Audit.org_id=$org_id_tok|s$ (Audit.event_type="agent.*" OR Audit.event_type="workload.*" OR Audit.event_type="workloads.*") Audit.event_type!="*.create" Audit.event_type!="*.update" Audit.event_type!="*.delete" BY _time Audit.timestamp Audit.href
       | lookup illumio_workloads_lookup href AS object_id OUTPUTNEW href AS workload_href, name, hostname, public_ip, labels
       | lookup illumio_workloads_lookup ven.href AS object_id OUTPUTNEW href AS workload_href, name, hostname, public_ip, labels
       | search $label_filter$ (hostname=$host_ip|s$ OR public_ip=$host_ip|s$)
@@ -79,8 +79,8 @@
       <chart>
         <search base="workload_lookup_base_search">
           <query>
-            | search agent.status.status=*
-            | rename agent.status.status AS Status
+            | search ven.status=*
+            | rename ven.status AS Status
             | stats count BY Status
           </query>
         </search>
@@ -89,7 +89,7 @@
         <option name="charting.legend.placement">none</option>
         <option name="refresh.display">progressbar</option>
         <drilldown>
-          <link target="_blank">search?q=%7C%20inputlookup%20illumio_workloads_lookup%20WHERE%20agent.status.status%3D$click.value$%20pce_fqdn%3D$pce_tok|s$%20org_id=$org_id_tok|s$%20deleted%3D0%20(hostname%3D$host_ip|s$%20OR%20public_ip%3D$host_ip|s$)%0A%7C%20search%20$label_filter$&amp;earliest=$earliest$&amp;latest=$latest$</link>
+          <link target="_blank">search?q=%7C%20inputlookup%20illumio_workloads_lookup%20WHERE%20ven.status%3D$click.value$%20pce_fqdn%3D$pce_tok|s$%20org_id=$org_id_tok|s$%20deleted%3D0%20(hostname%3D$host_ip|s$%20OR%20public_ip%3D$host_ip|s$)%0A%7C%20search%20$label_filter$&amp;earliest=$earliest$&amp;latest=$latest$</link>
         </drilldown>
       </chart>
     </panel>
@@ -207,11 +207,13 @@
         <search base="audit_base_search">
           <query>
             | search event_type=$event_type_tok|s$ severity=$severity_tok|s$ status=$status_tok|s$
+            | rename Audit.timestamp AS Timestamp
             | lookup illumio_labels_lookup pce_fqdn href AS labels OUTPUT key AS label_key value AS label_value
             | eval Labels = mvzip(label_key, label_value, ":")
             | fillnull value="-" notification_type Labels
-            | table _time pce_fqdn Workload Labels event_type notification_type severity status href
-            | rename _time AS Timestamp, pce_fqdn AS PCE, event_type AS "Event Type", notification_type AS "Notification Type", severity AS Severity, status AS Status
+            | table Timestamp pce_fqdn Workload Labels event_type notification_type severity status href
+            | rename pce_fqdn AS PCE, event_type AS "Event Type", notification_type AS "Notification Type", severity AS Severity, status AS Status
+            | eval Timestamp = strptime(Timestamp, "%Y-%m-%dT%H:%M:%S%Z")
             | fieldformat Timestamp = strftime(Timestamp, "%+")
             | sort -Timestamp
           </query>

--- a/IllumioAppforSplunk/default/data/ui/views/workload_operations.xml
+++ b/IllumioAppforSplunk/default/data/ui/views/workload_operations.xml
@@ -9,7 +9,7 @@
   </search>
   <search id="audit_base_search">
     <query>
-      | tstats `summariesonly` values(Audit.src_user) AS src_user, values(Audit.user) AS user, values(Audit.src_ip) AS src_ip, values(Audit.notification_type) AS notification_type, values(Audit.severity) AS severity, values(Audit.status) AS status, values(Audit.pce_fqdn) AS pce_fqdn, values(Audit.event_type) AS event_type, values(Audit.object_id) AS object_id FROM datamodel=Illumio.Audit WHERE Audit.pce_fqdn=$pce_tok|s$ Audit.org_id=$org_id_tok|s$ BY _time Audit.href
+      | tstats `summariesonly` values(Audit.src_user) AS src_user, values(Audit.user) AS user, values(Audit.src_ip) AS src_ip, values(Audit.notification_type) AS notification_type, values(Audit.severity) AS severity, values(Audit.status) AS status, values(Audit.pce_fqdn) AS pce_fqdn, values(Audit.event_type) AS event_type, values(Audit.object_id) AS object_id FROM datamodel=Illumio.Audit WHERE Audit.pce_fqdn=$pce_tok|s$ Audit.org_id=$org_id_tok|s$ BY _time Audit.timestamp Audit.href
     </query>
     <earliest>$time_range.earliest$</earliest>
     <latest>$time_range.latest$</latest>
@@ -99,25 +99,6 @@
         <option name="refresh.display">progressbar</option>
         <drilldown>
           <link target="_blank">search?q=%7C%20inputlookup%20illumio_workloads_lookup%20WHERE%20managed%3D1%20ven.version%3D$click.value$%20pce_fqdn=$pce_tok|s$%20org_id=$org_id_tok|s$%20deleted%3D0</link>
-        </drilldown>
-      </chart>
-    </panel>
-    <panel>
-      <title>Managed Workloads by Enforcement Mode</title>
-      <chart>
-        <search base="workload_lookup_base_search">
-          <query>
-            | search managed=1
-            | chart dc(href) AS "VEN Count" BY enforcement_mode
-            | rename enforcement_mode AS "Enforcement Mode"
-          </query>
-        </search>
-        <option name="charting.chart">pie</option>
-        <option name="charting.drilldown">all</option>
-        <option name="charting.fieldColors">{Count:0x70c580}</option>
-        <option name="refresh.display">progressbar</option>
-        <drilldown>
-          <link target="_blank">search?q=%7C%20inputlookup%20illumio_workloads_lookup%20WHERE%20managed%3D1%20enforcement_mode%3D$click.value$%20pce_fqdn=$pce_tok|s$%20org_id=$org_id_tok|s$%20deleted%3D0</link>
         </drilldown>
       </chart>
     </panel>

--- a/IllumioAppforSplunk/default/savedsearches.conf
+++ b/IllumioAppforSplunk/default/savedsearches.conf
@@ -7,8 +7,8 @@ auto_summarize = 1
 auto_summarize.cron_schedule = 55 0 * * 0
 auto_summarize.dispatch.earliest_time = -1w
 auto_summarize.dispatch.latest_time = now
-search = | tstats `summariesonly` values(Audit.pce_fqdn) AS pce_fqdn, values(Audit.org_id) AS org_id, values(Audit.severity) AS severity, values(Audit.object) AS object, values(Audit.object_category) AS object_category, values(Audit.object_id) AS object_id, values(Audit.user) AS user FROM datamodel=Illumio.Audit WHERE Audit.category=auditable BY _time Audit.event_type \
-    | rename Audit.event_type AS event_type
+search = | tstats `summariesonly` values(Audit.pce_fqdn) AS pce_fqdn, values(Audit.org_id) AS org_id, values(Audit.severity) AS severity, values(Audit.object) AS object, values(Audit.object_category) AS object_category, values(Audit.object_id) AS object_id, values(Audit.user) AS user FROM datamodel=Illumio.Audit WHERE Audit.category=auditable BY _time, Audit.timestamp, Audit.href, Audit.event_type \
+    | rename Audit.timestamp AS Timestamp, Audit.event_type AS event_type
 
 [Illumio_PortScan_Traffic]
 enableSched = 1
@@ -19,13 +19,14 @@ auto_summarize = 1
 auto_summarize.cron_schedule = 55 1 * * 0
 auto_summarize.dispatch.earliest_time = -1w
 auto_summarize.dispatch.latest_time = now
-search = | tstats `summariesonly` values(Traffic.pce_fqdn) AS pce_fqdn, values(Traffic.org_id) AS org_id, dc(Traffic.dest_port) AS ports_scanned, values(Traffic.src_host) AS src_host, values(Traffic.src_href) AS src_href, values(Traffic.dest_host) AS dest_host, values(Traffic.dest_href) AS dest_href FROM datamodel=Illumio.Traffic WHERE Traffic.direction=inbound BY _time Traffic.src_ip Traffic.dest_ip Traffic.network
+search = | tstats `summariesonly` values(Traffic.pce_fqdn) AS pce_fqdn, values(Traffic.org_id) AS org_id, dc(Traffic.dest_port) AS ports_scanned, values(Traffic.src_host) AS src_host, values(Traffic.src_href) AS src_href, values(Traffic.dest_host) AS dest_host, values(Traffic.dest_href) AS dest_href FROM datamodel=Illumio.Traffic WHERE Traffic.direction=inbound BY _time, Traffic.timestamp, Traffic.src_ip, Traffic.dest_ip, Traffic.network \
+    | rename Traffic.timestamp AS Timestamp, Traffic.src_ip AS src_ip, Traffic.dest_ip AS dest_ip, Traffic.network AS network
 
 [Illumio_PortScan]
 search = | savedsearch Illumio_PortScan_Traffic \
     | search pce_fqdn="$pce_fqdn$" org_id="$org_id$" \
-    | bin _time [| inputlookup illumio_port_scan_settings_lookup WHERE pce_fqdn="$pce_fqdn$" org_id="$org_id$" | eval result = "span=" . interval . "s" | return $result] \
-    | stats sum(ports_scanned) AS ports_scanned, latest(pce_fqdn) AS pce_fqdn, latest(org_id) AS org_id, latest(Traffic.src_ip) AS src_ip, latest(Traffic.dest_ip) AS dest_ip, latest(src_host) AS src_host, latest(src_href) AS src_href, latest(dest_host) AS dest_host, latest(dest_href) AS dest_href BY _time \
+    | bin Timestamp [| inputlookup illumio_port_scan_settings_lookup WHERE pce_fqdn="$pce_fqdn$" org_id="$org_id$" | eval result = "span=" . interval . "s" | return $result] \
+    | stats sum(ports_scanned) AS ports_scanned, latest(pce_fqdn) AS pce_fqdn, latest(org_id) AS org_id, latest(src_ip) AS src_ip, latest(dest_ip) AS dest_ip, latest(src_host) AS src_host, latest(src_href) AS src_href, latest(dest_host) AS dest_host, latest(dest_href) AS dest_href BY Timestamp \
     | lookup illumio_port_scan_settings_lookup pce_fqdn org_id OUTPUT threshold allowed_ips \
     | where ports_scanned > threshold AND NOT IN(allowed_ips, src_ip)
 
@@ -38,8 +39,8 @@ auto_summarize = 1
 auto_summarize.cron_schedule = 55 2 * * 0
 auto_summarize.dispatch.earliest_time = -1w
 auto_summarize.dispatch.latest_time = now
-search = | tstats `summariesonly` values(Audit.event_type) AS event_type, values(Audit.object) AS workload_hostname FROM datamodel=Illumio.Audit WHERE Audit.event_type="agent.tampering" BY _time, Audit.pce_fqdn, Audit.org_id, Audit.object_id \
-    | rename Audit.pce_fqdn AS pce_fqdn, Audit.org_id AS org_id, Audit.object_id AS ven_href
+search = | tstats `summariesonly` values(Audit.event_type) AS event_type, values(Audit.object) AS workload_hostname FROM datamodel=Illumio.Audit WHERE Audit.event_type="agent.tampering" BY _time, Audit.timestamp, Audit.href, Audit.pce_fqdn, Audit.org_id, Audit.object_id \
+    | rename Audit.Timestamp AS Timestamp, Audit.pce_fqdn AS pce_fqdn, Audit.org_id AS org_id, Audit.object_id AS ven_href
 
 [Illumio_Check_PCE_Collector_Data]
 enableSched = 0
@@ -70,4 +71,4 @@ alert.track = 1
 counttype = number of events
 quantity = 0
 relation = greater than
-search = | tstats `summariesonly` values(Audit.event_type) as event_type, values(Audit.href) as href from datamodel=Illumio.Audit WHERE Audit.event_type="agent.suspend" BY _time
+search = | tstats `summariesonly` values(Audit.event_type) as event_type, values(Audit.href) as href from datamodel=Illumio.Audit WHERE Audit.event_type="agent.suspend" BY Audit.timestamp


### PR DESCRIPTION
* fix bucketing for accelerated tstats searches by grouping on timestamp in addition to _time
* change Flows by Port panel in traffic explorer dashboard to group/drilldown by both port and protocol