### PR TITLE
Fix broken strptime formats

### DIFF
--- a/IllumioAppforSplunk/default/data/ui/views/change_monitoring.xml
+++ b/IllumioAppforSplunk/default/data/ui/views/change_monitoring.xml
@@ -92,7 +92,7 @@
             | fillnull value="-"
             | table timestamp, pce_fqdn, Username, policy_version, workloads_affected, commit_message, modifications, href
             | rename timestamp AS Timestamp, pce_fqdn AS "PCE", policy_version AS "Policy Version", workloads_affected AS "Workloads Affected", commit_message AS "Commit Message", modifications AS "Modified Objects", href AS "Event HREF"
-            | eval Timestamp=strptime('Timestamp',"%Y-%m-%dT%H:%M:%S.%f%Z")
+            | eval Timestamp=strptime('Timestamp',"%FT%T.%3N%Z")
             | fieldformat "Timestamp"=strftime('Timestamp',"%+")
             | sort - Timestamp
           </query>
@@ -186,7 +186,7 @@
             | fillnull value="-"
             | table timestamp, event_type, pce_fqdn, Username, properties, href
             | rename timestamp AS Timestamp, event_type AS "Event Type", pce_fqdn AS "PCE", properties AS "Resource Details", href AS "Event HREF"
-            | eval Timestamp=strptime('Timestamp',"%Y-%m-%dT%H:%M:%S.%f%Z")
+            | eval Timestamp=strptime('Timestamp',"%FT%T.%3N%Z")
             | fieldformat "Timestamp"=strftime('Timestamp',"%+")
             | sort - Timestamp
           </query>

--- a/IllumioAppforSplunk/default/data/ui/views/firewall_tampering_host.xml
+++ b/IllumioAppforSplunk/default/data/ui/views/firewall_tampering_host.xml
@@ -21,7 +21,7 @@
             | eval Quarantine = if(show_quarantine=1, "Quarantine Workload", "")
             | table Timestamp, pce_fqdn, org_id, Labels, workload_hostname, Quarantine, workload_href
             | rename pce_fqdn AS PCE, org_id AS "Org ID", workload_hostname AS Hostname
-            | eval Timestamp = strptime(Timestamp, "%Y-%m-%dT%H:%M:%S%Z")
+            | eval Timestamp = strptime(Timestamp, "%FT%T.%3N%Z")
             | fieldformat Timestamp = strftime(Timestamp, "%+")
             | sort -Timestamp
           </query>

--- a/IllumioAppforSplunk/default/data/ui/views/pce_user_authentication.xml
+++ b/IllumioAppforSplunk/default/data/ui/views/pce_user_authentication.xml
@@ -155,7 +155,7 @@
             | search $event_type_include$ $event_type_exclude$ $status_filter$ $severity_filter$ $notification_type_filter$
             | table event_href, Timestamp, PCE, event_type, src_user, user, src_ip, notification_type, severity, status
             | rename event_type AS "Event Type", src_user AS "Initiating User", user AS "Target User", src_ip AS "Source IP", notification_type AS "Notification Type", severity AS "Severity", status AS "Status"
-            | eval Timestamp = strptime('Timestamp', "%Y-%m-%dT%H:%M:%S.%f%Z")
+            | eval Timestamp = strptime('Timestamp', "%FT%T.%3N%Z")
             | fieldformat "Timestamp" = strftime('Timestamp', "%+")
             | sort -Timestamp
           </query>

--- a/IllumioAppforSplunk/default/data/ui/views/port_scan.xml
+++ b/IllumioAppforSplunk/default/data/ui/views/port_scan.xml
@@ -24,7 +24,6 @@
             | eval Quarantine = if(show_quarantine=1, "Quarantine Workload", "")
             | table Timestamp, pce_fqdn, org_id, src_ip, src_host, src_labels, dest_ip, dest_host, dest_labels, Quarantine, workload_href
             | rename pce_fqdn AS PCE, org_id AS "Org ID", src_host AS Source, src_ip AS "Source IP", src_labels AS "Source Labels", dest_host AS Destination, dest_ip AS "Destination IP", dest_labels AS "Destination Labels"
-            | eval Timestamp = strptime(Timestamp, "%Y-%m-%dT%H:%M:%S%Z")
             | fieldformat Timestamp = strftime(Timestamp, "%+")
             | sort -Timestamp
           </query>

--- a/IllumioAppforSplunk/default/data/ui/views/traffic_explorer.xml
+++ b/IllumioAppforSplunk/default/data/ui/views/traffic_explorer.xml
@@ -260,7 +260,7 @@
             | table Traffic.timestamp, Traffic.pce_fqdn, Source, direction, Destination, Traffic.dest_port, transport, flows, Traffic.action, src_labels, dest_labels
             | rename Traffic.timestamp AS Timestamp, Traffic.pce_fqdn AS "PCE", direction AS Direction, Traffic.dest_port AS "Port", transport AS Protocol, flows AS Flows, Traffic.action AS "Policy Decision", src_labels AS "Source Labels", dest_labels AS "Destination Labels"
             | fillnull value="-" "Source Labels" "Destination Labels"
-            | eval Timestamp = strptime(Timestamp, "%Y-%m-%dT%H:%M:%S%Z")
+            | eval Timestamp = strptime(Timestamp, "%FT%T%Z")
             | fieldformat Timestamp = strftime(Timestamp, "%+")
             | sort -Timestamp
           </query>

--- a/IllumioAppforSplunk/default/data/ui/views/workload_investigation.xml
+++ b/IllumioAppforSplunk/default/data/ui/views/workload_investigation.xml
@@ -142,8 +142,8 @@
             | eval Workload = if(isnull(name), hostname, name)
             | eval OS = os_id + " - " + os_detail
             | eval Online = if(online = 1, "online", "offline")
-            | eval "Updated at" = strftime(strptime(updated_at, "%Y-%m-%dT%H:%M:%S.%6NZ"), "%+")
-            | eval "Policy Applied at" = if(isnull('agent.status.security_policy_applied_at'), "No policy applied", strftime(strptime('agent.status.security_policy_applied_at', "%Y-%m-%dT%H:%M:%S.%6NZ"), "%+"))
+            | eval "Updated at" = strftime(strptime(updated_at, "%FT%T.%6NZ"), "%+")
+            | eval "Policy Applied at" = if(isnull('agent.status.security_policy_applied_at'), "No policy applied", strftime(strptime('agent.status.security_policy_applied_at', "%FT%T.%6NZ"), "%+"))
             | eval Labels = mvzip(label_key, label_value, ":")
             | eval Interfaces = mvzip(interface_name, interface_address, ": ")
             | eval PCE = if(isnotnull('agent.active_pce_fqdn'), 'agent.active_pce_fqdn', pce_fqdn)
@@ -213,7 +213,7 @@
             | fillnull value="-" notification_type Labels
             | table Timestamp pce_fqdn Workload Labels event_type notification_type severity status href
             | rename pce_fqdn AS PCE, event_type AS "Event Type", notification_type AS "Notification Type", severity AS Severity, status AS Status
-            | eval Timestamp = strptime(Timestamp, "%Y-%m-%dT%H:%M:%S%Z")
+            | eval Timestamp = strptime(Timestamp, "%FT%T.%3N%Z")
             | fieldformat Timestamp = strftime(Timestamp, "%+")
             | sort -Timestamp
           </query>

--- a/IllumioAppforSplunk/default/savedsearches.conf
+++ b/IllumioAppforSplunk/default/savedsearches.conf
@@ -25,6 +25,7 @@ search = | tstats `summariesonly` values(Traffic.pce_fqdn) AS pce_fqdn, values(T
 [Illumio_PortScan]
 search = | savedsearch Illumio_PortScan_Traffic \
     | search pce_fqdn="$pce_fqdn$" org_id="$org_id$" \
+    | eval Timestamp=strptime('Timestamp',"%FT%T%Z") \
     | bin Timestamp [| inputlookup illumio_port_scan_settings_lookup WHERE pce_fqdn="$pce_fqdn$" org_id="$org_id$" | eval result = "span=" . interval . "s" | return $result] \
     | stats sum(ports_scanned) AS ports_scanned, latest(pce_fqdn) AS pce_fqdn, latest(org_id) AS org_id, latest(src_ip) AS src_ip, latest(dest_ip) AS dest_ip, latest(src_host) AS src_host, latest(src_href) AS src_href, latest(dest_host) AS dest_host, latest(dest_href) AS dest_href BY Timestamp \
     | lookup illumio_port_scan_settings_lookup pce_fqdn org_id OUTPUT threshold allowed_ips \


### PR DESCRIPTION
Traffic timestamps don't have milliseconds, but Audit timestamps do. Fix broken subsearches without .%3N and change all strptime formatting to use %F and %T in place of %Y-%m-%d and %H:%M:%S respectively.

Also move the eval to before the bin command in the Illumio_PortScan savedsearch to make sure bucketing works in all cases, removing it from the search in port_scan.xml.

The change from .%f to .%3N is for consistency with other strptime calls.